### PR TITLE
added a fix to check if the page template detected is a basic template or one with a controller assigned.

### DIFF
--- a/DynamicRouting.Kentico.MVC/DynamicHttpHandler.cs
+++ b/DynamicRouting.Kentico.MVC/DynamicHttpHandler.cs
@@ -102,7 +102,7 @@ namespace DynamicRouting.Kentico.MVC
 
             if (PageHasTemplate(node) && PageHasBasicPageTemplate(node))
             {
-                return new DynamicRouteConfiguration("DynamicRouteTemplate", defaultAction, null, null, DynamicRouteType.Controller);
+                return new DynamicRouteConfiguration("DynamicRouteTemplate", "Index", null, null, DynamicRouteType.Controller);
             }
 
             if (!DynamicRoutingAnalyzer.TryFindMatch(node.ClassName, out var match))


### PR DESCRIPTION
Fixes #18 for every test scenario I have for the current website I'm developing.

Works for:

- Pages without Dynamic Routing enabled
- Pages with Dynamic Routing enabled and use MVC page templates with custom controllers

Not tested for:
- Pages with Dynamic Routing enabled and use basic MVC page templates

@KenticoDevTrev - Not sure if you could give this at test at your end, in particular basic page templates?